### PR TITLE
Bugfix notifcation message indent

### DIFF
--- a/Magento_AdminNotification/web/css/source/_extend.less
+++ b/Magento_AdminNotification/web/css/source/_extend.less
@@ -21,6 +21,7 @@
 .message-system-inner {
     box-shadow: @message-system__box-shadow;
     border-radius: @message-system__border-radius;
+    border: 0;
     margin: @message-system__margin;
     padding: @message-system__padding;
 
@@ -34,6 +35,11 @@
         &::before {
             left: @alert__padding-left;
         }
+    }
+
+    ._active & {
+        border-bottom-right-radius: 0;
+        border-bottom-left-radius: 0;
     }
 }
 
@@ -65,7 +71,6 @@
     }
 
     ._active & {
-        margin-top: -@message-system-short__padding-vertical;
         box-shadow: @message-system__box-shadow;
         border-radius: @message-system__border-radius;
         border-top-left-radius: 0;

--- a/web/css/source/expand/_variables.less
+++ b/web/css/source/expand/_variables.less
@@ -4,3 +4,4 @@
 
 @import './variables/_actions.less';
 @import './variables/_forms.less';
+@import './variables/_structure.less';

--- a/web/css/source/expand/modules/_admin-notification.less
+++ b/web/css/source/expand/modules/_admin-notification.less
@@ -8,4 +8,4 @@
 @message-system__border-radius: @radius__s;
 
 @message-system__padding: 0;
-@message-system__margin: @indent__base @indent__base 0 @indent__base;
+@message-system__margin: @indent__base 0 0;

--- a/web/css/source/expand/variables/_structure.less
+++ b/web/css/source/expand/variables/_structure.less
@@ -1,4 +1,5 @@
 //
 //  Components
 //  _____________________________________________
+
 @page-content__margin-horizontal: @content__indent;

--- a/web/css/source/expand/variables/_structure.less
+++ b/web/css/source/expand/variables/_structure.less
@@ -1,0 +1,4 @@
+//
+//  Components
+//  _____________________________________________
+@page-content__margin-horizontal: @content__indent;

--- a/web/css/source/extend/components/_messages.less
+++ b/web/css/source/extend/components/_messages.less
@@ -114,4 +114,6 @@
 //  Notices wrapper
 .notices-wrapper {
     min-height: unset;
+    margin-right: @page-content__margin-horizontal;
+    margin-left: @page-content__margin-horizontal;
 }

--- a/web/css/source/extend/variables/_structure.less
+++ b/web/css/source/extend/variables/_structure.less
@@ -65,6 +65,7 @@
 @page-wrapper__indent-left: @menu__width + @page-content__padding-horizontal;
 @page-wrapper__background-color: @neutral-95;
 
+@page-content__margin-horizontal: @content__indent;
 @page-content__padding-horizontal: @content__indent;
 // @page-content__padding-vertical: @content__indent;
 

--- a/web/css/source/extend/variables/_structure.less
+++ b/web/css/source/extend/variables/_structure.less
@@ -65,7 +65,6 @@
 @page-wrapper__indent-left: @menu__width + @page-content__padding-horizontal;
 @page-wrapper__background-color: @neutral-95;
 
-@page-content__margin-horizontal: @content__indent;
 @page-content__padding-horizontal: @content__indent;
 // @page-content__padding-vertical: @content__indent;
 


### PR DESCRIPTION
This corrects the extra indent, standardizes the notification message width to match the main content, removes the redundant notification border (consistent with collapsed views), and eliminates the negative margin to prevent shadow overlap.


| Now | After |
|--------|--------|
|  ![Screenshot 2025-04-13 at 20 51 45](https://github.com/user-attachments/assets/706d38c9-8f88-4f0f-a371-81db3115d4ae) | ![Screenshot 2025-04-13 at 20 50 28](https://github.com/user-attachments/assets/10462882-179f-40db-8971-e4dbae1462c4) | 

Closes #4 