### PR TITLE
Fix menu non-scrollable

### DIFF
--- a/Magento_Backend/web/css/source/extend/_menu.less
+++ b/Magento_Backend/web/css/source/extend/_menu.less
@@ -60,7 +60,7 @@
 //  _____________________________________________
 
 .menu-wrapper {
-    height: 100%;
+    min-height: 100%;
 
     .logo {
         margin: 1.4rem @indent__s @indent__s @indent__s;


### PR DESCRIPTION
Problem:
When there are many items in the left menu and you're on a page with little content, the menu becomes unscrollable.

Cause:
The menu-wrapper is set to height: 100%, which limits its height to match the page’s content. However, the inner menu elements can overflow this height when there are many items. The JavaScript that handles menu scrolling relies on the menu-wrapper's height for its calculations. So, even if the menu is longer than the visible area, the script mistakenly assumes it fits within the viewport and doesn’t enable scrolling.