### PR TITLE
Add view-transition

### DIFF
--- a/Magento_Backend/web/css/source/extend/_main.less
+++ b/Magento_Backend/web/css/source/extend/_main.less
@@ -15,6 +15,10 @@
 //  Page
 //  ---------------------------------------------
 
+@view-transition {
+    navigation: auto;
+}
+
 .page-separator {
     border-top: 0;
     margin-bottom: @indent__base;


### PR DESCRIPTION
This adds view-transitions to page transitions.

Since this is a progressive enhancement this has no negative side effects to users that don't have support for this CSS feature.

Using the default opt in to MPA view-transitions, it only adds a cross fade when transitioning pages.
Giving the Magento admin area a more app like feel.

Closes #8 