### PR TITLE
Fix missing tree-massactions.js file for admin orders mass actions

### DIFF
--- a/Magento_Sales/web/js/grid/tree-massactions.js
+++ b/Magento_Sales/web/js/grid/tree-massactions.js
@@ -1,0 +1,133 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/**
+ * @api
+ */
+define([
+    'ko',
+    'underscore',
+    'Magento_Ui/js/grid/massactions'
+], function (ko, _, Massactions) {
+    'use strict';
+
+    return Massactions.extend({
+        defaults: {
+            template: 'ui/grid/tree-massactions',
+            submenuTemplate: 'ui/grid/submenu',
+            listens: {
+                opened: 'hideSubmenus'
+            }
+        },
+
+        /**
+         * Initializes observable properties.
+         *
+         * @returns {Massactions} Chainable.
+         */
+        initObservable: function () {
+            this._super()
+                .recursiveObserveActions(this.actions());
+
+            return this;
+        },
+
+        /**
+         * Recursive initializes observable actions.
+         *
+         * @param {Array} actions - Action objects.
+         * @param {String} [prefix] - An optional string that will be prepended
+         *      to the "type" field of all child actions.
+         * @returns {Massactions} Chainable.
+         */
+        recursiveObserveActions: function (actions, prefix) {
+            _.each(actions, function (action) {
+                if (prefix) {
+                    action.type = prefix + '.' + action.type;
+                }
+
+                if (action.actions) {
+                    action.visible = ko.observable(false);
+                    action.parent = actions;
+                    this.recursiveObserveActions(action.actions, action.type);
+                }
+            }, this);
+
+            return this;
+        },
+
+        /**
+         * Applies specified action.
+         *
+         * @param {String} actionIndex - Actions' identifier.
+         * @returns {Massactions} Chainable.
+         */
+        applyAction: function (actionIndex) {
+            var action = this.getAction(actionIndex),
+                visibility;
+
+            if (action.visible) {
+                visibility = action.visible();
+
+                this.hideSubmenus(action.parent);
+                action.visible(!visibility);
+
+                return this;
+            }
+
+            return this._super(actionIndex);
+        },
+
+        /**
+         * Retrieves action object associated with a specified index.
+         *
+         * @param {String} actionIndex - Actions' identifier.
+         * @param {Array} actions - Action objects.
+         * @returns {Object} Action object.
+         */
+        getAction: function (actionIndex, actions) {
+            var currentActions = actions || this.actions(),
+                result = false;
+
+            _.find(currentActions, function (action) {
+                if (action.type === actionIndex) {
+                    result = action;
+
+                    return true;
+                }
+
+                if (action.actions) {
+                    result = this.getAction(actionIndex, action.actions);
+
+                    return result;
+                }
+            }, this);
+
+            return result;
+        },
+
+        /**
+         * Recursive hide all sub folders in given array.
+         *
+         * @param {Array} actions - Action objects.
+         * @returns {Massactions} Chainable.
+         */
+        hideSubmenus: function (actions) {
+            var currentActions = actions || this.actions();
+
+            _.each(currentActions, function (action) {
+                if (action.visible && action.visible()) {
+                    action.visible(false);
+                }
+
+                if (action.actions) {
+                    this.hideSubmenus(action.actions);
+                }
+            }, this);
+
+            return this;
+        }
+    });
+});


### PR DESCRIPTION
### Error Details

**Error Message:**
```
[2025-09-07 12:43:31] [ERROR] Failed to load the "Magento_Sales/js/grid/tree-massactions" component.
```

**When it occurs:**
- When accessing the admin orders page
- Specifically affects the mass actions functionality in the orders grid
- Appears in browser console


### Problem

The `mage-os/theme-adminhtml-m137` theme is missing the critical `tree-massactions.js` file located at `Magento_Sales/web/js/grid/tree-massactions.js`. This results in:

- **404 errors** when accessing the admin orders page
- **Broken mass actions functionality** in the orders grid
- **JavaScript errors** preventing proper operation of hierarchical mass actions in the admin interface

### Solution

Added the missing `tree-massactions.js` file with the complete implementation that:

1. **Extends the base Massactions component** from `Magento_Ui/js/grid/massactions`
2. **Implements tree-specific functionality** including:
   - Recursive observation of nested actions
   - Submenu visibility management
   - Hierarchical action handling
   - Parent-child relationship management

### Testing

✅ Admin orders page loads without 404 errors  
✅ Mass actions dropdown functions correctly  
✅ Hierarchical actions display and operate properly  
✅ No JavaScript console errors  