### PR TITLE
Fix the use of static blue to a theme colors instead

### DIFF
--- a/Magento_MediaGalleryUi/web/css/source/_extend.less
+++ b/Magento_MediaGalleryUi/web/css/source/_extend.less
@@ -97,12 +97,12 @@
         transition: @smooth__border-color, @smooth__box-shadow;
 
         &:hover {
-            border-color: @blue-50;
+            border-color: @color-primary;
         }
 
         &.selected {
             border-width: .1rem;
-            border-color: @blue-50;
+            border-color: @field-control__active__border-color;
             box-shadow: 0 0 0 .1rem @field-control__active__border-color;
         }
     }

--- a/Magento_MediaGalleryUi/web/css/source/_extend.less
+++ b/Magento_MediaGalleryUi/web/css/source/_extend.less
@@ -97,7 +97,7 @@
         transition: @smooth__border-color, @smooth__box-shadow;
 
         &:hover {
-            border-color: @field-control__focus__border-colo;
+            border-color: @field-control__focus__border-color;
         }
 
         &.selected {

--- a/Magento_MediaGalleryUi/web/css/source/_extend.less
+++ b/Magento_MediaGalleryUi/web/css/source/_extend.less
@@ -97,7 +97,7 @@
         transition: @smooth__border-color, @smooth__box-shadow;
 
         &:hover {
-            border-color: @color-primary;
+            border-color: @field-control__focus__border-colo;
         }
 
         &.selected {


### PR DESCRIPTION
This makes the border in the media gallery the same style as the button focus ring.

Using `@blue-50` makes it impossible without a override to change.

This was noticed in the Hyvä Commerce theme, where we changed the `@field-control__active__border-color` to a new color, only this was a weird mix do the `@blue-50`, so we had to force the border color to the same color.

Closes #30 