### PR TITLE
Allow page action buttons to wrap when the screen does not allow it anymore

### DIFF
--- a/Magento_Backend/web/css/source/extend/main/_actions-bar.less
+++ b/Magento_Backend/web/css/source/extend/main/_actions-bar.less
@@ -94,6 +94,9 @@
     }
 
     .page-actions-buttons {
+        flex-wrap: wrap;
+        gap: @indent__s 0.1rem;
+
         .action-default {
             &.primary {
                 margin-left: @indent__base;


### PR DESCRIPTION
Closes #34 

### Result

| Before | After |
| - | - |
| <img width="2048" height="1788" alt="hyva-commerce test_admin_customer_index_edit_id_1_key_404ed05a6a2cd53255b726a87e56ecf5b9573b0a7c1198d476c8c76388644197_" src="https://github.com/user-attachments/assets/f9790cf1-aa69-4fbe-a130-fc9395f76544" /> | <img width="2048" height="1788" alt="hyva-commerce test_admin_customer_index_edit_id_1_key_404ed05a6a2cd53255b726a87e56ecf5b9573b0a7c1198d476c8c76388644197_ (2)" src="https://github.com/user-attachments/assets/638b457e-6ec7-44c7-bbff-80742a3de421" /> |
