### PR TITLE
Added svg loader

### DIFF
--- a/web/css/source/extend/variables/_spinner.less
+++ b/web/css/source/extend/variables/_spinner.less
@@ -6,7 +6,7 @@
 @spinner__height: 4.8rem;
 
 @spinner__background-color: transparent;
-@spinner__background-image: url('@{baseDir}images/loader-1.gif');
+@spinner__background-image: url('@{baseDir}images/loader.svg');
 @spinner__background-position: 50% 50%;
 @spinner__background-repeat: no-repeat;
 @spinner__background-size: contain;
@@ -43,7 +43,7 @@
 @loader__height: 4.8rem;
 
 @loader__background-color: fade(@color-white, 50%);
-@loader__background-image: url('@{baseDir}images/loader-1.gif');
+@loader__background-image: url('@{baseDir}images/loader.svg');
 @loader__background-position: 50% 50%;
 @loader__background-repeat: no-repeat;
 @loader__background-size: contain;
@@ -58,7 +58,7 @@
 @loader-mask__height: 7.8rem;
 
 @loader-mask__background-color: fade(@color-white, 50%);
-@loader-mask__background-image: url('@{baseDir}images/loader-1.gif');
+@loader-mask__background-image: url('@{baseDir}images/loader.svg');
 @loader-mask__background-position: 50% 50%;
 @loader-mask__background-repeat: no-repeat;
 @loader-mask__background-size: 4.8rem;

--- a/web/images/loader.svg
+++ b/web/images/loader.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor">
+    <g>
+        <circle cx="12" cy="12" r="9.5" fill="none" stroke-linecap="round" stroke-width="3">
+            <animate attributeName="stroke-dasharray" calcMode="spline" dur="1.5s"
+                keySplines="0.42,0,0.58,1;0.42,0,0.58,1;0.42,0,0.58,1" keyTimes="0;0.475;0.95;1"
+                repeatCount="indefinite" values="0 150;42 150;42 150;42 150" />
+            <animate attributeName="stroke-dashoffset" calcMode="spline" dur="1.5s"
+                keySplines="0.42,0,0.58,1;0.42,0,0.58,1;0.42,0,0.58,1" keyTimes="0;0.475;0.95;1"
+                repeatCount="indefinite" values="0;-16;-59;-59" />
+        </circle>
+        <animateTransform attributeName="transform" dur="2s" repeatCount="indefinite" type="rotate"
+            values="0 12 12;360 12 12" />
+    </g>
+</svg>

--- a/web/images/loader.svg
+++ b/web/images/loader.svg
@@ -1,14 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" stroke="currentColor">
-    <g>
-        <circle cx="12" cy="12" r="9.5" fill="none" stroke-linecap="round" stroke-width="3">
-            <animate attributeName="stroke-dasharray" calcMode="spline" dur="1.5s"
-                keySplines="0.42,0,0.58,1;0.42,0,0.58,1;0.42,0,0.58,1" keyTimes="0;0.475;0.95;1"
-                repeatCount="indefinite" values="0 150;42 150;42 150;42 150" />
-            <animate attributeName="stroke-dashoffset" calcMode="spline" dur="1.5s"
-                keySplines="0.42,0,0.58,1;0.42,0,0.58,1;0.42,0,0.58,1" keyTimes="0;0.475;0.95;1"
-                repeatCount="indefinite" values="0;-16;-59;-59" />
-        </circle>
-        <animateTransform attributeName="transform" dur="2s" repeatCount="indefinite" type="rotate"
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path
+        d="M10.72 19.9a8 8 0 0 1-6.5-9.79 7.77 7.77 0 0 1 6.18-5.95 8 8 0 0 1 9.49 6.52A1.54 1.54 0 0 0 21.38 12h.13a1.37 1.37 0 0 0 1.38-1.54 11 11 0 1 0-12.7 12.39A1.54 1.54 0 0 0 12 21.34a1.47 1.47 0 0 0-1.28-1.44Z">
+        <animateTransform attributeName="transform" dur="0.75s" repeatCount="indefinite" type="rotate"
             values="0 12 12;360 12 12" />
-    </g>
+    </path>
 </svg>


### PR DESCRIPTION
This only updates the global spinners that are used mostly trough the UI.

There are a lot of hard coded spinners found trough Magento, for example `loader-2.gif`, which also found in jQuery scripts, For this reason this PR only focuses on the most global parts that are effected by this.

For most pages this would mean only the svg loader is loaded next to the `loader-2.gif`.

Closes #36 